### PR TITLE
Sort coordinates.json numerically #2210

### DIFF
--- a/processor/extract_frames_and_coordinates.py
+++ b/processor/extract_frames_and_coordinates.py
@@ -70,7 +70,13 @@ class FrameCoordinatesExtractor:
         needed_keys = ['trans_cw', 'rot_cw']
         output_object = {"coordinates": []}
 
-        for key in key_frames.keys():
+        # Numerically sorting 1 2 3 4 ... 99 100 101 .. instead of alphabetically sorting 1 10 100 101 102 ... 109 11 110 ..
+        keys = key_frames.keys()
+        keys = [int(key) for key in keys]
+        keys.sort()
+        keys = [str(key) for key in keys]
+        
+        for key in keys:
             sample = {}
             for needed_key in needed_keys:
                 if needed_key == 'trans_cw':


### PR DESCRIPTION
coordinates.json files originally had items in order alphabetically like 0, 1, 10, 100, 101, 102, ... 109, 11, 110, ...

They are now sorted numrically like 0, 1, 2, 3, ... 109, 110, 111, ...

The change is made upon coordinates.json file creation. Outdated coordinates.json files will still be out of order.

Developers can simply reorder the objects in an old coordinates.json file based on the filenames of the images to correct existing files.